### PR TITLE
update to 4.3.5

### DIFF
--- a/recipe/002-osx-test.patch
+++ b/recipe/002-osx-test.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile.am b/Makefile.am
-index fc9fd30..e3b0966 100644
+index 6d7085af..2fb56384 100755
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -389,7 +389,6 @@ endif
+@@ -436,7 +436,6 @@ endif
  #
  test_apps = \
  	tests/test_ancillaries \
@@ -10,7 +10,7 @@ index fc9fd30..e3b0966 100644
  	tests/test_pair_inproc \
  	tests/test_pair_tcp \
  	tests/test_reqrep_inproc \
-@@ -812,7 +811,6 @@ endif
+@@ -885,13 +884,11 @@ endif
  if !ON_MINGW
  if !ON_CYGWIN
  test_apps += \
@@ -18,3 +18,9 @@ index fc9fd30..e3b0966 100644
  	tests/test_ipc_wildcard \
  	tests/test_pair_ipc \
  	tests/test_rebind_ipc \
+ 	tests/test_reqrep_ipc \
+ 	tests/test_use_fd \
+-	tests/test_zmq_poll_fd \
+ 	tests/test_timeo \
+ 	tests/test_filter_ipc
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "zeromq" %}
-{% set version = "4.3.4" %}
-{% set sha256 = "c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5" %}
+{% set version = "4.3.5" %}
+{% set sha256 = "6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43" %}
 
 package:
   name: {{ name|lower }}
@@ -35,7 +35,7 @@ requirements:
     - m2-patch  # [win]
 
   host:
-    - libsodium
+    - libsodium 1.0.18
   run:
     - libsodium
 
@@ -75,7 +75,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:
-        - libsodium
+        - libsodium 1.0.18
         - {{ pin_subpackage("zeromq", exact=True) }}
       run:
         - libsodium
@@ -85,10 +85,18 @@ outputs:
         - test -f ${PREFIX}/lib/libzmq.a           # [unix]
 
 about:
-  home: http://zeromq.org
-  license: LGPL-3.0-or-later
-  license_file: COPYING.LESSER
+  home: https://zeromq.org
+  license: MPL-2.0
+  license_file: LICENSE
+  license_family: Other
   summary: A high-performance asynchronous messaging library.
+  description: |
+    The ZeroMQ lightweight messaging kernel is a library which extends the standard socket 
+    interfaces with features traditionally provided by specialised messaging middleware products. 
+    ZeroMQ sockets provide an abstraction of asynchronous message queues, multiple messaging 
+    patterns, message filtering (subscriptions), seamless access to multiple transport protocols and more.
+  dev_url: https://github.com/zeromq/libzmq
+  doc_url: https://zeromq.org/get-started/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changes:
- update to 4.3.5
- update license according to upstream
- skip 1 additional test on osx, this is not a regression, the test was failing on 4.3.4 as well.

Note: libsodium run constraints are handled through the local cbc.

https://github.com/zeromq/libzmq/tree/v4.3.5
https://github.com/zeromq/libzmq/blob/v4.3.5/LICENSE
https://github.com/zeromq/libzmq/blob/v4.3.5/NEWS