### PR TITLE
PKG-14086: drop zeromq-static from anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -8,4 +8,3 @@ upstream_sources:
       to_pattern: \1
     packages:
       - zeromq
-      - zeromq-static


### PR DESCRIPTION
## Summary
Remove `zeromq-static` from `upstream_sources.packages`.

## Ticket
PKG-14086

Made with [Cursor](https://cursor.com)